### PR TITLE
fix: group mapping for gitea oidc

### DIFF
--- a/src/operator/gitea.ts
+++ b/src/operator/gitea.ts
@@ -460,6 +460,7 @@ async function setGiteaOIDCConfig(update = false) {
   const teamNamespaceString = buildTeamString(env.teamNames)
 
   try {
+    // WARNING: Dont enclose the teamNamespaceString in double quotes, this will escape the string incorrectly and breaks OIDC group mapping in gitea
     const execCommand = [
       'sh',
       '-c',

--- a/src/operator/gitea.ts
+++ b/src/operator/gitea.ts
@@ -467,10 +467,10 @@ async function setGiteaOIDCConfig(update = false) {
       AUTH_ID=$(gitea admin auth list --vertical-bars | grep -E "\\|otomi-idp\\s+\\|" | grep -iE "\\|OAuth2\\s+\\|" | awk -F " " '{print $1}' | tr -d '\\n')
       if [ -z "$AUTH_ID" ]; then
         echo "Gitea OIDC config not found. Adding OIDC config for otomi-idp."
-        gitea admin auth add-oauth --name "otomi-idp" --key "${clientID}" --secret "${clientSecret}" --auto-discover-url "${discoveryURL}" --provider "openidConnect" --admin-group "team-admin" --group-claim-name "groups" --group-team-map "${teamNamespaceString}"
+        gitea admin auth add-oauth --name "otomi-idp" --key "${clientID}" --secret "${clientSecret}" --auto-discover-url "${discoveryURL}" --provider "openidConnect" --admin-group "team-admin" --group-claim-name "groups" --group-team-map '${teamNamespaceString}'
       elif ${update}; then
         echo "Gitea OIDC config is different. Updating OIDC config for otomi-idp."
-        gitea admin auth update-oauth --id "$AUTH_ID" --key "${clientID}" --secret "${clientSecret}" --auto-discover-url "${discoveryURL}" --group-team-map "${teamNamespaceString}"
+        gitea admin auth update-oauth --id "$AUTH_ID" --key "${clientID}" --secret "${clientSecret}" --auto-discover-url "${discoveryURL}" --group-team-map '${teamNamespaceString}'
       else
         echo "Gitea OIDC config is up to date."
       fi


### PR DESCRIPTION
See: [APL-204](https://jira.linode.com/browse/APL-204)

This fixes the Gitea oidc login 500 error, which happens because the group mapping is not formatted correctly