### PR TITLE
fix: use platform-admin group to map admin role in gitea

### DIFF
--- a/src/operator/gitea.ts
+++ b/src/operator/gitea.ts
@@ -468,7 +468,7 @@ async function setGiteaOIDCConfig(update = false) {
       AUTH_ID=$(gitea admin auth list --vertical-bars | grep -E "\\|otomi-idp\\s+\\|" | grep -iE "\\|OAuth2\\s+\\|" | awk -F " " '{print $1}' | tr -d '\\n')
       if [ -z "$AUTH_ID" ]; then
         echo "Gitea OIDC config not found. Adding OIDC config for otomi-idp."
-        gitea admin auth add-oauth --name "otomi-idp" --key "${clientID}" --secret "${clientSecret}" --auto-discover-url "${discoveryURL}" --provider "openidConnect" --admin-group "team-admin" --group-claim-name "groups" --group-team-map '${teamNamespaceString}'
+        gitea admin auth add-oauth --name "otomi-idp" --key "${clientID}" --secret "${clientSecret}" --auto-discover-url "${discoveryURL}" --provider "openidConnect" --admin-group "platform-admin" --group-claim-name "groups" --group-team-map '${teamNamespaceString}'
       elif ${update}; then
         echo "Gitea OIDC config is different. Updating OIDC config for otomi-idp."
         gitea admin auth update-oauth --id "$AUTH_ID" --key "${clientID}" --secret "${clientSecret}" --auto-discover-url "${discoveryURL}" --group-team-map '${teamNamespaceString}'


### PR DESCRIPTION
A user that belongs to platform-admin group should be an admin admin in gitea app. This PR aims to meet that requirement.

![image](https://github.com/user-attachments/assets/4f59011f-fc49-47a0-9560-380492c38b00)

![image](https://github.com/user-attachments/assets/45045ae6-9158-4c75-a29b-8bd9023b39eb)
