### PR TITLE
fix: platform admin

### DIFF
--- a/src/operator/gitea.test.ts
+++ b/src/operator/gitea.test.ts
@@ -6,7 +6,7 @@ describe('giteaOperator', () => {
   it('should create a valid group mapping string with all the teams', () => {
     const mappingString = buildTeamString(teamNames)
     expect(mappingString).to.be.equal(
-      '{"team-demo":{"otomi":["otomi-viewer","team-demo"]},"team-demo2":{"otomi":["otomi-viewer","team-demo2"]},"team-demo3":{"otomi":["otomi-viewer","team-demo3"]}}',
+      '{"platform-admin":{"otomi":["Owners"]},"team-demo":{"otomi":["otomi-viewer","team-demo"]},"team-demo2":{"otomi":["otomi-viewer","team-demo2"]},"team-demo3":{"otomi":["otomi-viewer","team-demo3"]}}',
     )
     expect(mappingString).to.not.contain('team-admin')
   })

--- a/src/operator/gitea.ts
+++ b/src/operator/gitea.ts
@@ -22,7 +22,7 @@ import {
   GITEA_URL_PORT,
   cleanEnv,
 } from '../validators'
-import { orgName, otomiChartsRepoName, otomiValuesRepoName, teamNameViewer, username } from './common'
+import { orgName, otomiChartsRepoName, otomiValuesRepoName, teamNameOwners, teamNameViewer, username } from './common'
 
 // Interfaces
 interface hookInfo {
@@ -442,10 +442,10 @@ async function setupGitea() {
 
 // Set Gitea Functions
 export function buildTeamString(teamNames: any[]): string {
-  if (teamNames === undefined) return '{}'
-  const teamObject: groupMapping = {}
+  const teamObject: groupMapping = { 'platform-admin': { otomi: [teamNameOwners] } }
+  if (teamNames === undefined) return JSON.stringify(teamObject)
   teamNames.forEach((teamName: string) => {
-    teamObject[`team-${teamName}`] = { otomi: ['otomi-viewer', `team-${teamName}`] }
+    teamObject[`team-${teamName}`] = { otomi: [teamNameViewer, `team-${teamName}`] }
   })
   return JSON.stringify(teamObject)
 }

--- a/src/tasks/common.ts
+++ b/src/tasks/common.ts
@@ -1,5 +1,0 @@
-export const orgName = 'otomi'
-export const teamNameOwners = 'Owners'
-export const teamNameViewer = 'otomi-viewer'
-export const otomiValuesRepoName = 'values'
-export const username = 'otomi-admin'


### PR DESCRIPTION
### Description:
This PR fixes group team mappings and assign `platform-admin` users as an owner in the `otomi` organization. It also allows `platform-admin` users to view the dashboard and repositories (see screenshots below).

### Screenshots:
![Screenshot 2024-10-17 at 09 49 48](https://github.com/user-attachments/assets/13a20588-d4b2-41a6-9930-c302feb46467)
