### PR TITLE
fix: check if robot  already exists and re-create secret if robot name is wrong

### DIFF
--- a/src/k8s.ts
+++ b/src/k8s.ts
@@ -48,6 +48,20 @@ export async function createSecret(name: string, namespace: string, data: Record
   console.info(`New secret ${name} has been created in the namespace ${namespace}`)
 }
 
+export async function replaceSecret(name: string, namespace: string, data: Record<string, any>): Promise<void> {
+  const b64enc = (val): string => Buffer.from(`${val}`).toString('base64')
+  const secret: V1Secret = {
+    ...new V1Secret(),
+    metadata: { ...new V1ObjectMeta(), name },
+    data: mapValues(data, b64enc) as {
+      [key: string]: string
+    },
+  }
+
+  await k8s.core().replaceNamespacedSecret(name, namespace, secret)
+  console.info(`Secret ${name} has been patched in the namespace ${namespace}`)
+}
+
 export type SecretPromise = Promise<{
   response: IncomingMessage
   body: V1Secret

--- a/src/operator/harbor.ts
+++ b/src/operator/harbor.ts
@@ -326,7 +326,12 @@ async function createSystemRobotSecret(): Promise<RobotSecret> {
   const { body: robotList } = await robotApi.listRobot()
   console.log('robotList', robotList)
   console.log('robot name: ', `${robotPrefix}${systemRobot.name}`)
-  const existing = robotList.find((i) => i.name === `${robotPrefix}${systemRobot.name}`)
+  const defaultRobotPrefix = 'robot$'
+  // Also check for default robot prefix because it can happen that the robot account was created with the default prefix
+  const existing = robotList.find(
+    (robot) =>
+      robot.name === `${robotPrefix}${systemRobot.name}` || robot.name === `${defaultRobotPrefix}${systemRobot.name}`,
+  )
   console.log('existing', existing)
   if (existing?.id) {
     const existingId = existing.id

--- a/src/operator/harbor.ts
+++ b/src/operator/harbor.ts
@@ -324,15 +324,12 @@ async function getBearerToken(): Promise<HttpBearerAuth> {
  */
 async function createSystemRobotSecret(): Promise<RobotSecret> {
   const { body: robotList } = await robotApi.listRobot()
-  console.log('robotList', robotList)
-  console.log('robot name: ', `${robotPrefix}${systemRobot.name}`)
   const defaultRobotPrefix = 'robot$'
   // Also check for default robot prefix because it can happen that the robot account was created with the default prefix
   const existing = robotList.find(
     (robot) =>
       robot.name === `${robotPrefix}${systemRobot.name}` || robot.name === `${defaultRobotPrefix}${systemRobot.name}`,
   )
-  console.log('existing', existing)
   if (existing?.id) {
     const existingId = existing.id
     await doApiCall(errors, `Deleting previous robot account ${systemRobot.name}`, () =>

--- a/src/operator/harbor.ts
+++ b/src/operator/harbor.ts
@@ -324,7 +324,10 @@ async function getBearerToken(): Promise<HttpBearerAuth> {
  */
 async function createSystemRobotSecret(): Promise<RobotSecret> {
   const { body: robotList } = await robotApi.listRobot()
+  console.log('robotList', robotList)
+  console.log('robot name: ', `${robotPrefix}${systemRobot.name}`)
   const existing = robotList.find((i) => i.name === `${robotPrefix}${systemRobot.name}`)
+  console.log('existing', existing)
   if (existing?.id) {
     const existingId = existing.id
     await doApiCall(errors, `Deleting previous robot account ${systemRobot.name}`, () =>


### PR DESCRIPTION
Fixes the bug in the operator that creates a robot account. Robot accounts in Harbor have prefixes with the default being `harbor$`. In the operator we configure it to be `otomi-`. But the configuration, due to a race condition, is applied after the first robot account is created. So it gets the `harbor$` prefix. This results in that the operator tries to re-create this robot account as it cannot find that it exist but when we create it Harbor response with robot account already exists. 
And 
Fixes the secret harbor-robot-admin where the name is wrong