### PR TITLE
fix: fail on request errors for triggering retry

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "operator:harbor": "node dist/operator/harbor.js",
     "operator:keycloak-dev": "NODE_TLS_REJECT_UNAUTHORIZED=0 ts-node-dev ./src/operator/keycloak.ts",
     "operator:keycloak": "node dist/operator/keycloak.js",
-    "test": "NODE_ENV=test mocha -r ts-node/register -r ts-custom-error --exit src/**/*.test.*"
+    "test": "NODE_ENV=test mocha -r ts-node/register -r ts-custom-error --exit src/*.test.* src/**/*.test.*"
   },
   "standard-version": {
     "skip": {

--- a/src/operator/keycloak.test.ts
+++ b/src/operator/keycloak.test.ts
@@ -32,9 +32,8 @@ describe('Keycloak User Group Management', () => {
         { name: 'group1', id: 'group1-id' },
         { name: 'group2', id: 'group2-id' },
       ]
-      api.users.realmUsersIdGroupsGet.resolves({ body: existingUserGroups })
 
-      await removeUserGroups(api, existingUser, existingUserGroups, ['group1'])
+      await removeUserGroups(api, existingUser.id, existingUserGroups, ['group1'])
 
       expect(api.users.realmUsersIdGroupsGroupIdDelete.calledWith(keycloakRealm, 'user-id', 'group2-id')).to.be.true
       expect(api.users.realmUsersIdGroupsGroupIdDelete.calledWith(keycloakRealm, 'user-id', 'group1-id')).to.be.false
@@ -49,9 +48,8 @@ describe('Keycloak User Group Management', () => {
       ]
       const existingUserGroups = [{ name: 'group1', id: 'group1-id' }]
       api.groups.realmGroupsGet.resolves({ body: currentKeycloakGroups })
-      api.users.realmUsersIdGroupsGet.resolves({ body: existingUserGroups })
 
-      await addUserGroups(api, existingUser, currentKeycloakGroups, existingUserGroups, ['group1', 'group2'])
+      await addUserGroups(api, existingUser.id, currentKeycloakGroups, existingUserGroups, ['group1', 'group2'])
 
       expect(api.users.realmUsersIdGroupsGroupIdPut.calledWith(keycloakRealm, 'user-id', 'group2-id')).to.be.true
       expect(api.users.realmUsersIdGroupsGroupIdPut.calledWith(keycloakRealm, 'user-id', 'group1-id')).to.be.false

--- a/src/operator/keycloak.test.ts
+++ b/src/operator/keycloak.test.ts
@@ -51,7 +51,7 @@ describe('Keycloak User Group Management', () => {
       api.groups.realmGroupsGet.resolves({ body: currentKeycloakGroups })
       api.users.realmUsersIdGroupsGet.resolves({ body: existingUserGroups })
 
-      await addUserGroups(api, existingUser, ['group1', 'group2'])
+      await addUserGroups(api, existingUser, currentKeycloakGroups, ['group1', 'group2'])
 
       expect(api.users.realmUsersIdGroupsGroupIdPut.calledWith(keycloakRealm, 'user-id', 'group2-id')).to.be.true
       expect(api.users.realmUsersIdGroupsGroupIdPut.calledWith(keycloakRealm, 'user-id', 'group1-id')).to.be.false

--- a/src/operator/keycloak.test.ts
+++ b/src/operator/keycloak.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai'
 import sinon from 'sinon'
-import { addUserGroups, removeUserGroups } from './keycloak'
+import { updateUserGroups } from './keycloak'
 
 describe('Keycloak User Group Management', () => {
   let api: any
@@ -28,12 +28,17 @@ describe('Keycloak User Group Management', () => {
 
   describe('removeUserGroups', () => {
     it('should remove user from groups not in teamGroups', async () => {
+      const groupsById = {
+        group1: 'group1-id',
+        group2: 'group2-id',
+      }
       const existingUserGroups = [
         { name: 'group1', id: 'group1-id' },
         { name: 'group2', id: 'group2-id' },
       ]
+      api.users.realmUsersIdGroupsGet.resolves({ body: existingUserGroups })
 
-      await removeUserGroups(api, existingUser.id, existingUserGroups, ['group1'])
+      await updateUserGroups(api, existingUser.id, groupsById, ['group1'])
 
       expect(api.users.realmUsersIdGroupsGroupIdDelete.calledWith(keycloakRealm, 'user-id', 'group2-id')).to.be.true
       expect(api.users.realmUsersIdGroupsGroupIdDelete.calledWith(keycloakRealm, 'user-id', 'group1-id')).to.be.false
@@ -42,14 +47,14 @@ describe('Keycloak User Group Management', () => {
 
   describe('addUserGroups', () => {
     it('should add user to groups in teamGroups if not already present', async () => {
-      const currentKeycloakGroups = [
-        { name: 'group1', id: 'group1-id' },
-        { name: 'group2', id: 'group2-id' },
-      ]
+      const groupsById = {
+        group1: 'group1-id',
+        group2: 'group2-id',
+      }
       const existingUserGroups = [{ name: 'group1', id: 'group1-id' }]
-      api.groups.realmGroupsGet.resolves({ body: currentKeycloakGroups })
+      api.users.realmUsersIdGroupsGet.resolves({ body: existingUserGroups })
 
-      await addUserGroups(api, existingUser.id, currentKeycloakGroups, existingUserGroups, ['group1', 'group2'])
+      await updateUserGroups(api, existingUser.id, groupsById, ['group1', 'group2'])
 
       expect(api.users.realmUsersIdGroupsGroupIdPut.calledWith(keycloakRealm, 'user-id', 'group2-id')).to.be.true
       expect(api.users.realmUsersIdGroupsGroupIdPut.calledWith(keycloakRealm, 'user-id', 'group1-id')).to.be.false

--- a/src/operator/keycloak.test.ts
+++ b/src/operator/keycloak.test.ts
@@ -38,7 +38,7 @@ describe('Keycloak User Group Management', () => {
       ]
       api.users.realmUsersIdGroupsGet.resolves({ body: existingUserGroups })
 
-      await updateUserGroups(api, existingUser.id, groupsById, ['group1'])
+      await updateUserGroups(api, existingUser, groupsById, ['group1'])
 
       expect(api.users.realmUsersIdGroupsGroupIdDelete.calledWith(keycloakRealm, 'user-id', 'group2-id')).to.be.true
       expect(api.users.realmUsersIdGroupsGroupIdDelete.calledWith(keycloakRealm, 'user-id', 'group1-id')).to.be.false
@@ -54,7 +54,7 @@ describe('Keycloak User Group Management', () => {
       const existingUserGroups = [{ name: 'group1', id: 'group1-id' }]
       api.users.realmUsersIdGroupsGet.resolves({ body: existingUserGroups })
 
-      await updateUserGroups(api, existingUser.id, groupsById, ['group1', 'group2'])
+      await updateUserGroups(api, existingUser, groupsById, ['group1', 'group2'])
 
       expect(api.users.realmUsersIdGroupsGroupIdPut.calledWith(keycloakRealm, 'user-id', 'group2-id')).to.be.true
       expect(api.users.realmUsersIdGroupsGroupIdPut.calledWith(keycloakRealm, 'user-id', 'group1-id')).to.be.false

--- a/src/operator/keycloak.test.ts
+++ b/src/operator/keycloak.test.ts
@@ -34,7 +34,7 @@ describe('Keycloak User Group Management', () => {
       ]
       api.users.realmUsersIdGroupsGet.resolves({ body: existingUserGroups })
 
-      await removeUserGroups(api, existingUser, ['group1'])
+      await removeUserGroups(api, existingUser, existingUserGroups, ['group1'])
 
       expect(api.users.realmUsersIdGroupsGroupIdDelete.calledWith(keycloakRealm, 'user-id', 'group2-id')).to.be.true
       expect(api.users.realmUsersIdGroupsGroupIdDelete.calledWith(keycloakRealm, 'user-id', 'group1-id')).to.be.false
@@ -51,7 +51,7 @@ describe('Keycloak User Group Management', () => {
       api.groups.realmGroupsGet.resolves({ body: currentKeycloakGroups })
       api.users.realmUsersIdGroupsGet.resolves({ body: existingUserGroups })
 
-      await addUserGroups(api, existingUser, currentKeycloakGroups, ['group1', 'group2'])
+      await addUserGroups(api, existingUser, currentKeycloakGroups, existingUserGroups, ['group1', 'group2'])
 
       expect(api.users.realmUsersIdGroupsGroupIdPut.calledWith(keycloakRealm, 'user-id', 'group2-id')).to.be.true
       expect(api.users.realmUsersIdGroupsGroupIdPut.calledWith(keycloakRealm, 'user-id', 'group1-id')).to.be.false

--- a/src/operator/keycloak.ts
+++ b/src/operator/keycloak.ts
@@ -714,9 +714,9 @@ async function createUpdateUser(api: any, userConf: UserRepresentation): Promise
     } else {
       console.info(`Creating user ${email}`)
       const assignableGroupNames = assignableGroups.filter((group) => group.name).map((group) => group.name) as string[]
-      for (let i = userConf.groups?.length || 0; i > 0; i--) {
+      for (let i = (userConf.groups?.length || 0) - 1; i >= 0; i--) {
         if (!assignableGroupNames.includes(userConf.groups![i])) {
-          userConf.groups!.splice(i)
+          userConf.groups!.splice(i, 1)
         }
       }
       await api.users.realmUsersPost(keycloakRealm, userConf)

--- a/src/operator/keycloak.ts
+++ b/src/operator/keycloak.ts
@@ -524,7 +524,6 @@ async function externalIDP(api: KeycloakApi) {
 
 async function internalIdp(api: KeycloakApi) {
   // IDP instead of broker
-  // create groups
   console.info('Getting realm groups')
   const updatedExistingGroups = ((await api.groups.realmGroupsGet(keycloakRealm)).body || []) as GroupRepresentation[]
 

--- a/src/operator/keycloak.ts
+++ b/src/operator/keycloak.ts
@@ -667,8 +667,8 @@ async function createUpdateUser(api: any, userConf: UserRepresentation): Promise
   const groups = userConf.groups as string[]
   const { email } = userConf
   console.info(`Getting users for ${email}`)
-  const existingUsersByUserEmail = (await api.users.realmUsersGet(keycloakRealm, false, email))
-    .body as UserRepresentation[]
+  const existingUsersByUserEmail: UserRepresentation[] = (await api.users.realmUsersGet(keycloakRealm, false, email))
+    .body
   const existingUser: UserRepresentation = existingUsersByUserEmail?.[0]
   const existingGroups: GroupRepresentation[] = (await api.groups.realmGroupsGet(keycloakRealm)).body
   const groupsByName: Record<string, string> = Object.fromEntries(existingGroups.map((group) => [group.name, group.id]))

--- a/src/operator/keycloak.ts
+++ b/src/operator/keycloak.ts
@@ -458,7 +458,8 @@ async function keycloakRealmProviderConfigurer(api: KeycloakApi) {
   )
 
   // Create Otomi Client
-  const client = createClient(env.REDIRECT_URIS, env.KEYCLOAK_HOSTNAME_URL, env.KEYCLOAK_CLIENT_SECRET)
+  const uniqueUrls = [...new Set(env.REDIRECT_URIS)]
+  const client = createClient(uniqueUrls, env.KEYCLOAK_HOSTNAME_URL, env.KEYCLOAK_CLIENT_SECRET)
   console.info('Getting otomi client')
   const allClients = ((await api.clients.realmClientsGet(keycloakRealm)).body || []) as ClientRepresentation[]
   if (allClients.some((el) => el.name === client.name)) {

--- a/src/operator/keycloak.ts
+++ b/src/operator/keycloak.ts
@@ -315,9 +315,9 @@ if (typeof require !== 'undefined' && require.main === module) {
   })
 }
 async function keycloakConfigMapChanges(api: KeycloakApi) {
-  keycloakRealmProviderConfigurer(api)
-  if (env.FEAT_EXTERNAL_IDP === 'true') externalIDP(api)
-  else internalIdp(api)
+  await keycloakRealmProviderConfigurer(api)
+  if (env.FEAT_EXTERNAL_IDP === 'true') await externalIDP(api)
+  else await internalIdp(api)
 }
 
 async function createKeycloakConnection(): Promise<KeycloakConnection> {

--- a/src/operator/keycloak.ts
+++ b/src/operator/keycloak.ts
@@ -450,8 +450,8 @@ async function keycloakRealmProviderConfigurer(api: KeycloakApi) {
   console.info('Getting client email claim mapper')
   const allClaims = ((await api.protocols.realmClientsIdProtocolMappersModelsGet(keycloakRealm, client.id!)).body ||
     []) as ProtocolMapperRepresentation[]
-  const mapper = createClientEmailClaimMapper()
-  if (!allClaims.some((el) => el.name === mapper.name)) {
+  if (!allClaims.some((el) => el.name === 'email')) {
+    const mapper = createClientEmailClaimMapper()
     console.info('Creating client email claim mapper')
     await api.protocols.realmClientsIdProtocolMappersModelsPost(keycloakRealm, client.id!, mapper)
   }

--- a/src/operator/keycloak.ts
+++ b/src/operator/keycloak.ts
@@ -39,7 +39,7 @@ import {
   createTeamUser,
   mapTeamsToRoles,
 } from '../tasks/keycloak/realm-factory'
-import { isUpdated } from '../utils'
+import { isObjectSubsetDifferent } from '../utils'
 import {
   cleanEnv,
   KEYCLOAK_TOKEN_OFFLINE_MAX_TTL_ENABLED,
@@ -378,7 +378,7 @@ async function keycloakRealmProviderConfigurer(api: KeycloakApi) {
   console.info(`Getting realm ${keycloakRealm}`)
   try {
     const existingRealm = (await api.realms.realmGet(keycloakRealm)).body
-    if (isUpdated(realmConf, existingRealm)) {
+    if (isObjectSubsetDifferent(realmConf, existingRealm)) {
       console.info(`Updating realm ${keycloakRealm}`)
       await api.realms.realmPut(keycloakRealm, realmConf)
     } else {
@@ -436,7 +436,7 @@ async function keycloakRealmProviderConfigurer(api: KeycloakApi) {
   const allClients = ((await api.clients.realmClientsGet(keycloakRealm)).body || []) as ClientRepresentation[]
   const existingClient = allClients.find((el) => el.name === client.name)
   if (existingClient) {
-    if (isUpdated(client, existingClient)) {
+    if (isObjectSubsetDifferent(client, existingClient)) {
       console.info('Updating otomi client')
       await api.clients.realmClientsIdPut(keycloakRealm, existingClient.id!, client)
     } else {
@@ -678,7 +678,7 @@ async function createUpdateUser(api: any, userConf: UserRepresentation): Promise
       const omitUpdateFields = ['realmRoles', 'initialPassword', 'requiredActions', 'groups']
       if (!existingUser.requiredActions?.includes('UPDATE_PASSWORD')) omitUpdateFields.push('credentials')
       const updatedUserConf = omit(userConf, omitUpdateFields)
-      if (isUpdated(updatedUserConf, existingUser)) {
+      if (isObjectSubsetDifferent(updatedUserConf, existingUser)) {
         console.info(`Updating user ${email}`)
         await api.users.realmUsersIdPut(keycloakRealm, existingUser.id as string, updatedUserConf)
       } else {

--- a/src/operator/keycloak.ts
+++ b/src/operator/keycloak.ts
@@ -672,7 +672,7 @@ async function createUpdateUser(api: any, userConf: UserRepresentation): Promise
     .body as UserRepresentation[]
   const existingUser: UserRepresentation = existingUsersByUserEmail?.[0]
   const existingGroups: GroupRepresentation[] = (await api.groups.realmGroupsGet(keycloakRealm)).body
-  const groupsByName = Object.fromEntries(existingGroups.map((group) => [group.name, group.id]))
+  const groupsByName: Record<string, string> = Object.fromEntries(existingGroups.map((group) => [group.name, group.id]))
   try {
     if (existingUser) {
       const omitUpdateFields = ['realmRoles', 'initialPassword', 'requiredActions', 'groups']
@@ -689,7 +689,7 @@ async function createUpdateUser(api: any, userConf: UserRepresentation): Promise
       console.info(`Creating user ${email}`)
       for (let i = (userConf.groups?.length || 0) - 1; i >= 0; i--) {
         const groupName = userConf.groups![i]
-        if (!groupsByName.has(groupName)) {
+        if (!(groupName in groupsByName)) {
           console.info(`Group ${groupName} does not exist, skipping assignment`)
           userConf.groups!.splice(i, 1)
         }

--- a/src/operator/keycloak.ts
+++ b/src/operator/keycloak.ts
@@ -677,6 +677,8 @@ export async function addUserGroups(
           if (groupId) {
             await api.users.realmUsersIdGroupsGroupIdPut(keycloakRealm, existingUser.id as string, groupId)
           }
+        } else {
+          console.info(`Group ${teamGroup} does not exist, skipping assignment`)
         }
       }),
     )
@@ -715,7 +717,9 @@ async function createUpdateUser(api: any, userConf: UserRepresentation): Promise
       console.info(`Creating user ${email}`)
       const assignableGroupNames = assignableGroups.filter((group) => group.name).map((group) => group.name) as string[]
       for (let i = (userConf.groups?.length || 0) - 1; i >= 0; i--) {
-        if (!assignableGroupNames.includes(userConf.groups![i])) {
+        const groupName = userConf.groups![i]
+        if (!assignableGroupNames.includes(groupName)) {
+          console.info(`Group ${groupName} does not exist, skipping assignment`)
           userConf.groups!.splice(i, 1)
         }
       }

--- a/src/operator/keycloak.ts
+++ b/src/operator/keycloak.ts
@@ -629,7 +629,7 @@ export async function updateUserGroups(
   teamGroups: string[],
 ): Promise<void> {
   const userId = user.id!
-  const existingUserGroups = (await api.users.realmUsersIdGroupsGet(keycloakRealm, userId)).body
+  const { body: existingUserGroups } = await api.users.realmUsersIdGroupsGet(keycloakRealm, userId)
   const userGroupIds: Set<string> = new Set(existingUserGroups.map((userGroup) => groupsByName[userGroup.name]))
   const teamGroupIds: Set<string> = new Set()
   let groupUpdates = 0

--- a/src/operator/keycloak.ts
+++ b/src/operator/keycloak.ts
@@ -635,7 +635,7 @@ export async function updateUserGroups(
       const teamGroupId = groupsByName[teamGroup]
       if (teamGroupId) {
         if (!userGroupIds.has(teamGroupId)) {
-          console.info(`Adding user ${user.username} to ${teamGroup}`)
+          console.info(`Adding user ${user.email} to ${teamGroup}`)
           await api.users.realmUsersIdGroupsGroupIdPut(keycloakRealm, userId, teamGroupId)
           groupUpdates += 1
         }
@@ -649,14 +649,14 @@ export async function updateUserGroups(
     existingUserGroups.map(async (userGroup): Promise<void> => {
       const userGroupId = groupsByName[userGroup.name]
       if (!teamGroupIds.has(userGroupId)) {
-        console.info(`Removing user ${user.username} from ${userGroup.name}`)
+        console.info(`Removing user ${user.email} from ${userGroup.name}`)
         await api.users.realmUsersIdGroupsGroupIdDelete(keycloakRealm, userId, userGroupId)
         groupUpdates += 1
       }
     }),
   )
   if (!groupUpdates) {
-    console.log(`No groups updated for user ${user.username}`)
+    console.log(`No groups updated for user ${user.email}`)
   }
 }
 

--- a/src/operator/keycloak.ts
+++ b/src/operator/keycloak.ts
@@ -699,13 +699,13 @@ async function createUpdateUser(api: any, userConf: UserRepresentation): Promise
 
   try {
     if (existingUser) {
-      const omitUpdateFields = ['groups', 'realmRoles', 'initialPassword', 'requiredActions']
+      const omitUpdateFields = ['realmRoles', 'initialPassword', 'requiredActions']
       if (!existingUser.requiredActions?.includes('UPDATE_PASSWORD')) omitUpdateFields.push('credentials')
       const updatedUserConf = omit(userConf, omitUpdateFields)
       if (isUpdated(updatedUserConf, existingUser)) {
         console.debug(`User with email ${email} already exists, updating user`)
         console.info(`Updating user ${email}`)
-        await api.users.realmUsersIdPut(keycloakRealm, existingUser.id as string, updatedUserConf)
+        await api.users.realmUsersIdPut(keycloakRealm, existingUser.id as string, omit(updatedUserConf, ['groups']))
         await removeUserGroups(api, existingUser, groups)
         await addUserGroups(api, existingUser, assignableGroups, groups)
       } else {

--- a/src/operator/keycloak.ts
+++ b/src/operator/keycloak.ts
@@ -416,7 +416,7 @@ async function keycloakRealmProviderConfigurer(api: KeycloakApi) {
     env.KEYCLOAK_REALM,
   )
   console.info(`Getting all roles from realm ${keycloakRealm}`)
-  const existingRealmRoles = ((await api.roles.realmRolesGet(keycloakRealm)).body || []) as RealmRole[]
+  const existingRealmRoles = (await api.roles.realmRolesGet(keycloakRealm)).body as RealmRole[]
   await Promise.all(
     teamRoles.map((role) => {
       const exists = existingRealmRoles.some((el) => el.name === role.name!)
@@ -433,7 +433,7 @@ async function keycloakRealmProviderConfigurer(api: KeycloakApi) {
   const uniqueUrls = [...new Set(env.REDIRECT_URIS)]
   const client = createClient(uniqueUrls, env.KEYCLOAK_HOSTNAME_URL, env.KEYCLOAK_CLIENT_SECRET)
   console.info('Getting otomi client')
-  const allClients = ((await api.clients.realmClientsGet(keycloakRealm)).body || []) as ClientRepresentation[]
+  const allClients = (await api.clients.realmClientsGet(keycloakRealm)).body as ClientRepresentation[]
   const existingClient = allClients.find((el) => el.name === client.name)
   if (existingClient) {
     if (isObjectSubsetDifferent(client, existingClient)) {
@@ -490,9 +490,9 @@ async function externalIDP(api: KeycloakApi) {
   )
 
   console.info('Getting role mappers')
-  const existingMappers = ((
+  const existingMappers = (
     await api.providers.realmIdentityProviderInstancesAliasMappersGet(keycloakRealm, env.IDP_ALIAS)
-  ).body || []) as IdentityProviderMapperRepresentation[]
+  ).body as IdentityProviderMapperRepresentation[]
 
   try {
     await Promise.all(
@@ -525,23 +525,23 @@ async function externalIDP(api: KeycloakApi) {
 async function internalIdp(api: KeycloakApi) {
   // IDP instead of broker
   console.info('Getting realm groups')
-  const updatedExistingGroups = ((await api.groups.realmGroupsGet(keycloakRealm)).body || []) as GroupRepresentation[]
+  const updatedExistingGroups = (await api.groups.realmGroupsGet(keycloakRealm)).body as GroupRepresentation[]
 
   // get updated existing roles
   console.info(`Getting all roles from realm ${keycloakRealm}`)
-  const updatedExistingRealmRoles = ((await api.roles.realmRolesGet(keycloakRealm)).body || []) as RealmRole[]
+  const updatedExistingRealmRoles = (await api.roles.realmRolesGet(keycloakRealm)).body as RealmRole[]
 
   // get clients for access roles
   console.info(`Getting client realm-management from realm ${keycloakRealm}`)
-  const realmManagementClients = ((await api.clients.realmClientsGet(keycloakRealm, 'realm-management')).body ||
-    []) as ClientRepresentation[]
+  const realmManagementClients = (await api.clients.realmClientsGet(keycloakRealm, 'realm-management'))
+    .body as ClientRepresentation[]
   const realmManagementClient = realmManagementClients.find(
     (el) => el.clientId === 'realm-management',
   ) as ClientRepresentation
 
   console.info(`Getting realm-management roles from realm ${keycloakRealm}`)
-  const realmManagementRoles = ((await api.roles.realmClientsIdRolesGet(keycloakRealm, realmManagementClient.id!))
-    .body || []) as RealmRole[]
+  const realmManagementRoles = (await api.roles.realmClientsIdRolesGet(keycloakRealm, realmManagementClient.id!))
+    .body as RealmRole[]
   const realmManagementRole = realmManagementRoles.find((el) => el.name === 'manage-realm') as RoleRepresentation
   const userManagementRole = realmManagementRoles.find((el) => el.name === 'manage-users') as RoleRepresentation
   const userViewerRole = realmManagementRoles.find((el) => el.name === 'view-users') as RoleRepresentation
@@ -552,8 +552,8 @@ async function internalIdp(api: KeycloakApi) {
       const groupName = group.name!
       // get realm roles for group
       console.info(`Getting all roles from realm ${keycloakRealm} for group ${groupName}`)
-      const existingRoleMappings = ((await api.roleMapper.realmGroupsIdRoleMappingsRealmGet(keycloakRealm, group.id!))
-        .body || []) as RoleRepresentation[]
+      const existingRoleMappings = (await api.roleMapper.realmGroupsIdRoleMappingsRealmGet(keycloakRealm, group.id!))
+        .body as RoleRepresentation[]
       const existingRoleMapping = existingRoleMappings.find((el) => el.name === groupName)
       if (!existingRoleMapping) {
         // set realm roles
@@ -567,13 +567,13 @@ async function internalIdp(api: KeycloakApi) {
       }
       // get client roles for group
       console.info(`Getting all client roles from realm ${keycloakRealm} for group ${groupName}`)
-      const existingClientRoleMappings = ((
+      const existingClientRoleMappings = (
         await api.clientRoleMappings.realmGroupsIdRoleMappingsClientsClientGet(
           keycloakRealm,
           group.id!,
           realmManagementClient.id!,
         )
-      ).body || []) as RoleRepresentation[]
+      ).body as RoleRepresentation[]
       const existingClientRoleMapping = existingClientRoleMappings.find((el) => el.name === groupName)
       if (!existingClientRoleMapping) {
         // let team members see other users
@@ -603,7 +603,7 @@ async function manageGroups(api: KeycloakApi) {
   const teamGroups = createGroups(env.TEAM_IDS)
   console.info('Getting realm groups')
   try {
-    const existingGroups = ((await api.groups.realmGroupsGet(keycloakRealm)).body || []) as GroupRepresentation[]
+    const existingGroups = (await api.groups.realmGroupsGet(keycloakRealm)).body as GroupRepresentation[]
     await Promise.all(
       teamGroups.map((group) => {
         const groupName = group.name!

--- a/src/operator/keycloak.ts
+++ b/src/operator/keycloak.ts
@@ -729,7 +729,14 @@ async function manageUsers(users: any[]) {
   const connection = await createKeycloakConnection()
   const api = setupKeycloakApi(connection)
   // Create/Update users in realm 'otomi'
-  await Promise.all(users.map((user) => createUpdateUser(api, user)))
+  await Promise.all(
+    users.map((user) =>
+      createUpdateUser(
+        api,
+        createTeamUser(user.email, user.firstName, user.lastName, user.groups, user.initialPassword),
+      ),
+    ),
+  )
   // Delete users not in users list
   await deleteUsers(api, users)
 }

--- a/src/tasks/keycloak/errors.ts
+++ b/src/tasks/keycloak/errors.ts
@@ -7,7 +7,8 @@ export function extractError(operationName: string, error: Error): WrappedError 
   if (error instanceof WrappedError) return error
   let errorDetail: any
   if (error instanceof KeyCloakHttpError || error instanceof K8sHttpError) {
-    errorDetail = `status code: ${error.statusCode} - response: ${error.body}`
+    let responseStr = typeof error.body === 'object' ? JSON.stringify(error.body) : error.body
+    errorDetail = `status code: ${error.statusCode} - response: ${responseStr}`
   } else {
     errorDetail = error
   }

--- a/src/tasks/keycloak/errors.ts
+++ b/src/tasks/keycloak/errors.ts
@@ -7,7 +7,7 @@ export function extractError(operationName: string, error: Error): WrappedError 
   if (error instanceof WrappedError) return error
   let errorDetail: any
   if (error instanceof KeyCloakHttpError || error instanceof K8sHttpError) {
-    let responseStr = typeof error.body === 'object' ? JSON.stringify(error.body) : error.body
+    const responseStr = typeof error.body === 'object' ? JSON.stringify(error.body) : error.body
     errorDetail = `status code: ${error.statusCode} - response: ${responseStr}`
   } else {
     errorDetail = error

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -2,9 +2,51 @@ import { expect } from 'chai'
 import fetch from 'node-fetch'
 import sinon from 'sinon'
 import './test-init'
-import { objectToArray, waitTillAvailable } from './utils'
+import { isUpdated, objectToArray, waitTillAvailable } from './utils'
 
 describe('utils', () => {
+  describe('isUpdated', () => {
+    it('should detect equal objects', () => {
+      expect(
+        isUpdated(
+          { a: 1, b: 'x', c: { c1: false, c2: ['a', 'b'] } },
+          { a: 1, b: 'x', c: { c1: false, c2: ['b', 'a'] } },
+        ),
+      ).to.be.false
+    })
+
+    it('should detect subset equal objects', () => {
+      expect(isUpdated({ b: 'x', c: { c1: false } }, { a: 1, b: 'x', c: { c1: false } })).to.be.false
+    })
+
+    it('should detect changes in objects', () => {
+      expect(
+        isUpdated(
+          { a: 1, b: 'y', c: { c1: false, c2: ['a', 'b'] } },
+          { a: 1, b: 'x', c: { c1: false, c2: ['b', 'a'] } },
+        ),
+      ).to.be.true
+      expect(
+        isUpdated(
+          { a: 2, b: 'x', c: { c1: false, c2: ['a', 'b'] } },
+          { a: 1, b: 'x', c: { c1: false, c2: ['b', 'a'] } },
+        ),
+      ).to.be.true
+      expect(
+        isUpdated(
+          { a: 1, b: 'x', c: { c1: true, c2: ['a', 'b'] } },
+          { a: 1, b: 'x', c: { c1: false, c2: ['b', 'a'] } },
+        ),
+      ).to.be.true
+      expect(
+        isUpdated(
+          { a: 1, b: 'x', c: { c1: false, c2: ['a', 'b', 'c'] } },
+          { a: 1, b: 'x', c: { c1: false, c2: ['b', 'a'] } },
+        ),
+      ).to.be.true
+    })
+  })
+
   it('objectToArray should convert an object to array', (done) => {
     const obj = {
       bla: {

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -2,44 +2,44 @@ import { expect } from 'chai'
 import fetch from 'node-fetch'
 import sinon from 'sinon'
 import './test-init'
-import { isUpdated, objectToArray, waitTillAvailable } from './utils'
+import { isObjectSubsetDifferent, objectToArray, waitTillAvailable } from './utils'
 
 describe('utils', () => {
-  describe('isUpdated', () => {
-    it('should detect equal objects', () => {
+  describe('isObjectSubsetDifferent', () => {
+    it('should detect equivalent objects', () => {
       expect(
-        isUpdated(
+        isObjectSubsetDifferent(
           { a: 1, b: 'x', c: { c1: false, c2: ['a', 'b'] } },
           { a: 1, b: 'x', c: { c1: false, c2: ['b', 'a'] } },
         ),
       ).to.be.false
     })
 
-    it('should detect subset equal objects', () => {
-      expect(isUpdated({ b: 'x', c: { c1: false } }, { a: 1, b: 'x', c: { c1: false } })).to.be.false
+    it('should detect subset equivalent objects', () => {
+      expect(isObjectSubsetDifferent({ b: 'x', c: { c1: false } }, { a: 1, b: 'x', c: { c1: false } })).to.be.false
     })
 
     it('should detect changes in objects', () => {
       expect(
-        isUpdated(
+        isObjectSubsetDifferent(
           { a: 1, b: 'y', c: { c1: false, c2: ['a', 'b'] } },
           { a: 1, b: 'x', c: { c1: false, c2: ['b', 'a'] } },
         ),
       ).to.be.true
       expect(
-        isUpdated(
+        isObjectSubsetDifferent(
           { a: 2, b: 'x', c: { c1: false, c2: ['a', 'b'] } },
           { a: 1, b: 'x', c: { c1: false, c2: ['b', 'a'] } },
         ),
       ).to.be.true
       expect(
-        isUpdated(
+        isObjectSubsetDifferent(
           { a: 1, b: 'x', c: { c1: true, c2: ['a', 'b'] } },
           { a: 1, b: 'x', c: { c1: false, c2: ['b', 'a'] } },
         ),
       ).to.be.true
       expect(
-        isUpdated(
+        isObjectSubsetDifferent(
           { a: 1, b: 'x', c: { c1: false, c2: ['a', 'b', 'c'] } },
           { a: 1, b: 'x', c: { c1: false, c2: ['b', 'a'] } },
         ),

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -23,28 +23,23 @@ export function objectToArray(obj: any, keyName: string, keyValue: string): any[
   return arr
 }
 
-export function isArrayUpdated(arr: any[], ref: any[]): boolean {
+export function isArrayDifferent(arr: any[], ref: any[]): boolean {
   if (!ref) return arr.length === 0
   if (arr.length !== ref.length) return true
   if (arr.length === 0) return false
   return !arr.every((item) => ref.includes(item))
 }
 
-export function isUpdated(obj: any, ref: any): boolean {
-  const updated: string[] = []
-  Object.entries(obj).forEach(([key, value]) => {
+export function isObjectSubsetDifferent(obj: any, ref: any): boolean {
+  return !Object.entries(obj).every(([key, value]) => {
     const refValue = ref[key]
     if (Array.isArray(value)) {
-      if (isArrayUpdated(value, refValue)) updated.push(key)
+      if (isArrayDifferent(value, refValue)) return false
     } else if (typeof value === 'object') {
-      if (isUpdated(value, refValue)) updated.push(key)
-    } else if (refValue !== value) updated.push(key)
-  })
-  if (updated.length > 0) {
-    console.info(`Updated keys ${updated.join(', ')}`)
+      if (isObjectSubsetDifferent(value, refValue)) return false
+    } else if (refValue !== value) return false
     return true
-  }
-  return false
+  })
 }
 
 export type openapiResponse = {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -27,7 +27,7 @@ export function isArrayUpdated(arr: any[], ref: any[]): boolean {
   if (!ref) return arr.length === 0
   if (arr.length !== ref.length) return true
   if (arr.length === 0) return false
-  return arr.sort() === ref.sort()
+  return !arr.every((item) => ref.includes(item))
 }
 
 export function isUpdated(obj: any, ref: any): boolean {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -23,6 +23,30 @@ export function objectToArray(obj: any, keyName: string, keyValue: string): any[
   return arr
 }
 
+export function isArrayUpdated(arr: any[], ref: any[]): boolean {
+  if (!ref) return arr.length === 0
+  if (arr.length !== ref.length) return true
+  if (arr.length === 0) return false
+  return arr.sort() === ref.sort()
+}
+
+export function isUpdated(obj: any, ref: any): boolean {
+  const updated: string[] = []
+  for (const [key, value] of Object.entries(obj)) {
+    const refValue = ref[key]
+    if (Array.isArray(value)) {
+      if (isArrayUpdated(value, refValue)) updated.push(key)
+    } else if (typeof value === 'object') {
+      if (isUpdated(value, refValue)) updated.push(key)
+    } else if (refValue !== value) updated.push(key)
+  }
+  if (updated.length > 0) {
+    console.info(`Updated keys ${updated.join(', ')}`)
+    return true
+  }
+  return false
+}
+
 export type openapiResponse = {
   response: http.IncomingMessage
   body?: any

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -32,14 +32,14 @@ export function isArrayUpdated(arr: any[], ref: any[]): boolean {
 
 export function isUpdated(obj: any, ref: any): boolean {
   const updated: string[] = []
-  for (const [key, value] of Object.entries(obj)) {
+  Object.entries(obj).forEach(([key, value]) => {
     const refValue = ref[key]
     if (Array.isArray(value)) {
       if (isArrayUpdated(value, refValue)) updated.push(key)
     } else if (typeof value === 'object') {
       if (isUpdated(value, refValue)) updated.push(key)
     } else if (refValue !== value) updated.push(key)
-  }
+  })
   if (updated.length > 0) {
     console.info(`Updated keys ${updated.join(', ')}`)
     return true


### PR DESCRIPTION
This PR replaces all instances of `utils.doApiCall`, which adds errors to a list but never raises them. This causes rejected requests to external APIs to get logged, but never retried. As a consequence, the operator will on a temporary failure (e.g. connection glitch) never reconcile fully until it is restarted.

The only additional functionality of this function wrapper is that it passes over 409 errors (conflict) which might not be the most sensible thing to do in all situations. Where appropriate, the retry after a failed request (i.e. due to a race condition of two operator instances) with this particular error should come to the same result – otherwise it is more likely that the operator needs to be refined for such cases instead of suppressing the error.

For reducing the chance of race conditions, some more functions in role setup are awaited, and a single connection / api object is used during one update cycle. The update cycle of user groups has been consolidated into one function, and some unused or overly nested function calls have been removed.

In that regard, some objects are now being checked if they need updating (client, realm, users) before posting an update request. This should also lead to less errors (e.g. a known issue with duplicate redirect URLs), which seem to be a result of the Keycloak API not being able to handle nested object updates in all cases. There might still be potential in extending this approach to further objects.