### PR TITLE
feat: add transformed-email to otomi client token

### DIFF
--- a/src/operator/keycloak.ts
+++ b/src/operator/keycloak.ts
@@ -396,7 +396,7 @@ async function keycloakRealmProviderConfigurer(api: KeycloakApi) {
   const existingOpenIdClientScope = clientScopes.find((el) => el.name === openIdClientScope.name)
   if (existingOpenIdClientScope) {
     console.info('Updating openid client scope')
-    if (existingOpenIdClientScope.protocolMappers?.some((el) => el.name === transformedEmailMapper.name)) {
+    if (!existingOpenIdClientScope.protocolMappers?.some((el) => el.name === transformedEmailMapper.name)) {
       console.info('Adding transformed email mapper to openid client scope')
       await api.protocols.realmClientScopesIdProtocolMappersModelsPost(
         keycloakRealm,

--- a/src/operator/keycloak.ts
+++ b/src/operator/keycloak.ts
@@ -677,6 +677,8 @@ async function createUpdateUser(api: any, userConf: UserRepresentation): Promise
       const omitUpdateFields = ['realmRoles', 'initialPassword', 'requiredActions', 'groups']
       if (!existingUser.requiredActions?.includes('UPDATE_PASSWORD')) omitUpdateFields.push('credentials')
       const updatedUserConf = omit(userConf, omitUpdateFields)
+      updatedUserConf.attributes = updatedUserConf.attributes || {}
+      existingUser.attributes = existingUser.attributes || {}
       if (isObjectSubsetDifferent(updatedUserConf, existingUser)) {
         console.info(`Updating user ${email}`)
         await api.users.realmUsersIdPut(keycloakRealm, existingUser.id as string, updatedUserConf)

--- a/src/operator/keycloak.ts
+++ b/src/operator/keycloak.ts
@@ -36,7 +36,7 @@ import {
   createIdProvider,
   createLoginThemeConfig,
   createRealm,
-  createTeamUser,
+  createTeamUser, createTransformedEmailScope,
   mapTeamsToRoles,
 } from '../tasks/keycloak/realm-factory'
 import { isObjectSubsetDifferent } from '../utils'
@@ -394,17 +394,29 @@ async function keycloakRealmProviderConfigurer(api: KeycloakApi) {
   }
 
   // Create Client Scopes
-  const scope = createClientScopes()
-  console.info('Getting openid client scope')
+  const openIdClientScope = createClientScopes()
+  console.info('Getting all client scopes')
   const clientScopes = (await api.clientScope.realmClientScopesGet(keycloakRealm)).body as ClientScopeRepresentation[]
-  const existingScope = clientScopes.find((el) => el.name === scope.name)
-  if (existingScope) {
+  const existingOpenIdClientScope = clientScopes.find((el) => el.name === openIdClientScope.name)
+  if (existingOpenIdClientScope) {
     console.info('Updating openid client scope')
     // @NOTE this PUT operation is almost pointless as it is not updating deep nested properties because of various db constraints
-    await api.clientScope.realmClientScopesIdPut(keycloakRealm, existingScope.id!, scope)
+    await api.clientScope.realmClientScopesIdPut(keycloakRealm, existingOpenIdClientScope.id!, openIdClientScope)
   } else {
     console.info('Creating openid client scope')
-    await api.clientScope.realmClientScopesPost(keycloakRealm, scope)
+    await api.clientScope.realmClientScopesPost(keycloakRealm, openIdClientScope)
+  }
+
+  const transformedEmailScope = createTransformedEmailScope()
+  console.info('Getting transformed-email client scope')
+  const existingTransformedEmailScope = clientScopes.find((el) => el.name === transformedEmailScope.name)
+  if (existingTransformedEmailScope) {
+    console.info('Updating transformed-email client scope')
+    // @NOTE this PUT operation is almost pointless as it is not updating deep nested properties because of various db constraints
+    await api.clientScope.realmClientScopesIdPut(keycloakRealm, existingTransformedEmailScope.id!, transformedEmailScope)
+  } else {
+    console.info('Creating transformed-email client scope')
+    await api.clientScope.realmClientScopesPost(keycloakRealm, transformedEmailScope)
   }
 
   const teamRoles = mapTeamsToRoles(

--- a/src/operator/keycloak.ts
+++ b/src/operator/keycloak.ts
@@ -396,7 +396,6 @@ async function keycloakRealmProviderConfigurer(api: KeycloakApi) {
   const existingOpenIdClientScope = clientScopes.find((el) => el.name === openIdClientScope.name)
   if (existingOpenIdClientScope) {
     console.info('Updating openid client scope')
-    // @NOTE this PUT operation is almost pointless as it is not updating deep nested properties because of various db constraints
     if (existingOpenIdClientScope.protocolMappers?.some((el) => el.name === transformedEmailMapper.name)) {
       console.info('Adding transformed email mapper to openid client scope')
       await api.protocols.realmClientScopesIdProtocolMappersModelsPost(
@@ -405,6 +404,7 @@ async function keycloakRealmProviderConfigurer(api: KeycloakApi) {
         transformedEmailMapper,
       )
     }
+    // @NOTE this PUT operation is almost pointless as it is not updating deep nested properties because of various db constraints
     await api.clientScope.realmClientScopesIdPut(keycloakRealm, existingOpenIdClientScope.id!, openIdClientScope)
   } else {
     console.info('Creating openid client scope')

--- a/src/operator/keycloak.ts
+++ b/src/operator/keycloak.ts
@@ -699,6 +699,7 @@ async function createUpdateUser(api: any, userConf: UserRepresentation): Promise
           userConf.groups!.splice(i, 1)
         }
       }
+      console.info('createUpdateUser: ' + JSON.stringify(userConf))
       await api.users.realmUsersPost(keycloakRealm, userConf)
     }
   } catch (error) {
@@ -724,9 +725,10 @@ async function deleteUsers(api: any, users: any[]) {
 }
 
 async function manageUsers(api: KeycloakApi, users: any[]) {
+  console.info('manageUsers: ' + JSON.stringify(users))
   // Create/Update users in realm 'otomi'
   await Promise.all(
-    users.map((user) =>
+        users.map((user) =>
       createUpdateUser(
         api,
         createTeamUser(user.email, user.firstName, user.lastName, user.groups, user.initialPassword),

--- a/src/tasks/keycloak/config.test.ts
+++ b/src/tasks/keycloak/config.test.ts
@@ -1,0 +1,53 @@
+import { expect } from 'chai'
+import { teamUserCfgTpl } from './config'
+
+describe('teamUserCfgTpl', () => {
+  it('should return the correct user configuration object', () => {
+    const email = 'demo@example.com'
+    const firstName = 'John'
+    const lastName = 'Doe'
+    const groups = ['team-group']
+    const initialPassword = 'secret123'
+
+    const result = teamUserCfgTpl(email, firstName, lastName, groups, initialPassword)
+
+    // Basic property checks:
+    expect(result).to.have.property('username', email)
+    expect(result).to.have.property('enabled', true)
+    expect(result).to.have.property('email', email)
+    expect(result).to.have.property('emailVerified', true)
+    expect(result).to.have.property('firstName', firstName)
+    expect(result).to.have.property('lastName', lastName)
+    expect(result).to.have.property('realmRoles').that.eql(['teamMember'])
+    expect(result).to.have.property('groups').that.eql(groups)
+    expect(result).to.have.property('requiredActions').that.eql([])
+
+    expect(result).to.have.property('credentials').that.is.an('array')
+    const creds = (result.credentials as Array<Record<string, unknown>>)
+    expect(creds[0]).to.deep.equal({
+      type: 'password',
+      value: initialPassword,
+      temporary: true,
+    })
+
+    expect(result).to.have.property('attributes').that.is.an('object')
+    const attrs = result.attributes as Record<string, unknown>
+    expect(attrs).to.have.property('nickname', 'demo-example-com')
+  })
+
+  it('should correctly set nickname attribute', () => {
+    const testCases = [
+      { email: 'my.user@domain.co', expectedNickname: 'my-user-domain-co' },
+      { email: 'user.name@email.org', expectedNickname: 'user-name-email-org' },
+      { email: 'plain@domain', expectedNickname: 'plain-domain' },
+    ]
+
+    for (const { email, expectedNickname } of testCases) {
+      const userConf = teamUserCfgTpl(email, 'Test', 'User', [], 'pw')
+
+      expect(userConf).to.have.property('attributes').that.is.an('object')
+      const attrs = userConf.attributes as Record<string, unknown>
+      expect(attrs).to.have.property('nickname', expectedNickname)
+    }
+  })
+})

--- a/src/tasks/keycloak/config.ts
+++ b/src/tasks/keycloak/config.ts
@@ -1,9 +1,5 @@
-/* eslint-disable no-template-curly-in-string */
-/* eslint-disable camelcase */
-import { ClientScopeRepresentation, ProtocolMapperRepresentation } from '@linode/keycloak-client-node'
+import { ProtocolMapperRepresentation } from '@linode/keycloak-client-node'
 import axios from 'axios'
-import { defaultsDeep } from 'lodash'
-
 export const keycloakRealm = 'otomi'
 
 export const defaultsIdpMapperTpl = (
@@ -125,6 +121,21 @@ export const clientScopeCfgTpl = (protocolMappers: ProtocolMapperRepresentation[
   protocolMappers,
 })
 
+export const transformedEmailMapper = {
+  name: 'transformed-email',
+  protocol: 'openid-connect',
+  protocolMapper: 'oidc-usermodel-attribute-mapper',
+  config: {
+    'user.attribute': 'transformedEmail',
+    'id.token.claim': 'true',
+    'access.token.claim': 'true',
+    'userinfo.token.claim': 'true',
+    'claim.name': 'transformed_email',
+    'jsonType.label': 'String',
+  },
+}
+
+
 export const protocolMappersList: Array<Record<string, unknown>> = [
   {
     name: 'groups',
@@ -195,6 +206,7 @@ export const protocolMappersList: Array<Record<string, unknown>> = [
       'jsonType.label': 'String',
     },
   },
+  transformedEmailMapper,
 ]
 
 export const roleTpl = (name: string, groupMapping: string, containerId: string): Record<string, unknown> => ({
@@ -273,7 +285,7 @@ export const otomiClientCfgTpl = (
 ): Record<string, unknown> => ({
   id: 'otomi',
   secret,
-  defaultClientScopes: ['openid', 'email', 'profile', 'transformed-email'],
+  defaultClientScopes: ['openid', 'email', 'profile'],
   redirectUris,
   standardFlowEnabled: true,
   implicitFlowEnabled: true,
@@ -297,29 +309,4 @@ export type OidcProviderCfg = {
   userinfo_endpoint: string
   authorization_endpoint: string
   end_session_endpoint: string
-}
-
-export const transformedEmailScope = {
-  name: 'transformed-email',
-  protocol: 'openid-connect',
-  attributes: {
-    'include.in.token.scope': 'true',
-    'display.on.consent.screen': 'true',
-  },
-  protocolMappers: [
-    {
-      name: 'transformed-email',
-      protocol: 'openid-connect',
-      protocolMapper: 'oidc-usermodel-attribute-mapper',
-      consentRequired: false,
-      config: {
-        'user.attribute': 'transformedEmail',
-        'id.token.claim': 'true',
-        'access.token.claim': 'true',
-        'userinfo.token.claim': 'true',
-        'claim.name': 'transformed_email',
-        'jsonType.label': 'String',
-      },
-    },
-  ],
 }

--- a/src/tasks/keycloak/config.ts
+++ b/src/tasks/keycloak/config.ts
@@ -91,7 +91,6 @@ export const teamUserCfgTpl = (
   ],
   requiredActions: [],
   attributes: {
-    transformedEmail: email.replace(/@/g, '-').replace(/\./g, '-'),
     nickname: email.replace(/@/g, '-').replace(/\./g, '-'),
   },
 })
@@ -121,21 +120,6 @@ export const clientScopeCfgTpl = (protocolMappers: ProtocolMapperRepresentation[
   },
   protocolMappers,
 })
-
-export const transformedEmailMapper = {
-  name: 'transformed-email',
-  protocol: 'openid-connect',
-  protocolMapper: 'oidc-usermodel-attribute-mapper',
-  config: {
-    'user.attribute': 'transformedEmail',
-    'id.token.claim': 'true',
-    'access.token.claim': 'true',
-    'userinfo.token.claim': 'true',
-    'claim.name': 'transformed_email',
-    'jsonType.label': 'String',
-  },
-}
-
 
 export const protocolMappersList: Array<Record<string, unknown>> = [
   {
@@ -207,7 +191,6 @@ export const protocolMappersList: Array<Record<string, unknown>> = [
       'jsonType.label': 'String',
     },
   },
-  transformedEmailMapper,
 ]
 
 export const roleTpl = (name: string, groupMapping: string, containerId: string): Record<string, unknown> => ({

--- a/src/tasks/keycloak/config.ts
+++ b/src/tasks/keycloak/config.ts
@@ -1,7 +1,8 @@
 /* eslint-disable no-template-curly-in-string */
 /* eslint-disable camelcase */
-import { ProtocolMapperRepresentation } from '@linode/keycloak-client-node'
+import { ClientScopeRepresentation, ProtocolMapperRepresentation } from '@linode/keycloak-client-node'
 import axios from 'axios'
+import { defaultsDeep } from 'lodash'
 
 export const keycloakRealm = 'otomi'
 
@@ -194,20 +195,6 @@ export const protocolMappersList: Array<Record<string, unknown>> = [
       'jsonType.label': 'String',
     },
   },
-  {
-    name: 'transformed-email',
-    protocol: 'openid-connect',
-    protocolMapper: 'oidc-usermodel-attribute-mapper',
-    consentRequired: false,
-    config: {
-      'user.attribute': 'transformedEmail',
-      'id.token.claim': 'true',
-      'access.token.claim': 'true',
-      'userinfo.token.claim': 'true',
-      'claim.name': 'transformed_email',
-      'jsonType.label': 'String',
-    },
-  },
 ]
 
 export const roleTpl = (name: string, groupMapping: string, containerId: string): Record<string, unknown> => ({
@@ -310,4 +297,29 @@ export type OidcProviderCfg = {
   userinfo_endpoint: string
   authorization_endpoint: string
   end_session_endpoint: string
+}
+
+export const transformedEmailScope = {
+  name: 'transformed-email',
+  protocol: 'openid-connect',
+  attributes: {
+    'include.in.token.scope': 'true',
+    'display.on.consent.screen': 'true',
+  },
+  protocolMappers: [
+    {
+      name: 'transformed-email',
+      protocol: 'openid-connect',
+      protocolMapper: 'oidc-usermodel-attribute-mapper',
+      consentRequired: false,
+      config: {
+        'user.attribute': 'transformedEmail',
+        'id.token.claim': 'true',
+        'access.token.claim': 'true',
+        'userinfo.token.claim': 'true',
+        'claim.name': 'transformed_email',
+        'jsonType.label': 'String',
+      },
+    },
+  ],
 }

--- a/src/tasks/keycloak/config.ts
+++ b/src/tasks/keycloak/config.ts
@@ -92,6 +92,7 @@ export const teamUserCfgTpl = (
   requiredActions: [],
   attributes: {
     transformedEmail: email.replace(/@/g, '-').replace(/\./g, '-'),
+    nickname: email.replace(/@/g, '-').replace(/\./g, '-'),
   },
 })
 

--- a/src/tasks/keycloak/config.ts
+++ b/src/tasks/keycloak/config.ts
@@ -191,6 +191,20 @@ export const protocolMappersList: Array<Record<string, unknown>> = [
       'jsonType.label': 'String',
     },
   },
+  {
+    name: 'transformed-email',
+    protocol: 'openid-connect',
+    protocolMapper: 'oidc-usermodel-attribute-mapper',
+    consentRequired: false,
+    config: {
+      'user.attribute': 'transformedEmail',
+      'id.token.claim': 'true',
+      'access.token.claim': 'true',
+      'userinfo.token.claim': 'true',
+      'claim.name': 'transformed_email',
+      'jsonType.label': 'String',
+    },
+  },
 ]
 
 export const roleTpl = (name: string, groupMapping: string, containerId: string): Record<string, unknown> => ({

--- a/src/tasks/keycloak/config.ts
+++ b/src/tasks/keycloak/config.ts
@@ -93,6 +93,9 @@ export const teamUserCfgTpl = (
     },
   ],
   requiredActions: [],
+  attributes: {
+    transformedEmail: email.replace(/@/g, '-').replace(/\./g, '-'),
+  },
 })
 
 export const realmCfgTpl = (realm: string): Record<string, unknown> => ({

--- a/src/tasks/keycloak/config.ts
+++ b/src/tasks/keycloak/config.ts
@@ -286,7 +286,7 @@ export const otomiClientCfgTpl = (
 ): Record<string, unknown> => ({
   id: 'otomi',
   secret,
-  defaultClientScopes: ['openid', 'email', 'profile'],
+  defaultClientScopes: ['openid', 'email', 'profile', 'transformed-email'],
   redirectUris,
   standardFlowEnabled: true,
   implicitFlowEnabled: true,

--- a/src/tasks/keycloak/realm-factory.test.ts
+++ b/src/tasks/keycloak/realm-factory.test.ts
@@ -1,0 +1,54 @@
+import { expect } from 'chai'
+import { UserRepresentation } from '@linode/keycloak-client-node'
+import { createTeamUser } from './realm-factory'
+
+describe('createTeamUser', () => {
+  it('should return a valid UserRepresentation with merged defaults', () => {
+    const email = 'john@example.com'
+    const firstName = 'John'
+    const lastName = 'Doe'
+    const groups = ['group1', 'group2']
+    const initialPassword = 'password123'
+
+    const userRepresentation: UserRepresentation = createTeamUser(
+      email,
+      firstName,
+      lastName,
+      groups,
+      initialPassword
+    )
+
+    expect(userRepresentation.email).to.be.equal(email)
+    expect(userRepresentation.enabled).to.be.true
+    expect(userRepresentation.emailVerified).to.be.true
+    expect(userRepresentation.username).to.be.equal(email)
+    expect(userRepresentation.firstName).to.be.equal(firstName)
+    expect(userRepresentation.lastName).to.be.equal(lastName)
+    expect(userRepresentation.groups).to.eql(groups)
+    expect(userRepresentation.realmRoles).to.eql(['teamMember'])
+    expect(userRepresentation.requiredActions).to.eql([])
+    expect(userRepresentation.credentials![0]).to.eql({
+      type: 'password',
+      value: initialPassword,
+      temporary: true,
+    })
+
+    expect(userRepresentation.attributes).to.be.an('object')
+    const transformed = email.replace(/@/g, '-').replace(/\./g, '-')
+    expect(userRepresentation.attributes!.nickname).to.be.equal(transformed)
+  })
+
+  it('should correctly transform various email formats for the nickname', () => {
+    const testCases = [
+      { email: 'simple@domain.com', expected: 'simple-domain-com' },
+      { email: 'with.dots@some.co.uk', expected: 'with-dots-some-co-uk' },
+      { email: 'no-dots@domain', expected: 'no-dots-domain' },
+    ]
+
+    for (const { email, expected } of testCases) {
+      const userRep = createTeamUser(email, 'FName', 'LName', [], 'pw')
+      expect(userRep.attributes).to.be.an('object')
+      expect(userRep.attributes!.nickname).to.be.equal(expected)
+    }
+  })
+})

--- a/src/tasks/keycloak/realm-factory.ts
+++ b/src/tasks/keycloak/realm-factory.ts
@@ -125,10 +125,19 @@ export function createTeamUser(
   groups: string[],
   initialPassword: string,
 ): UserRepresentation {
+  // 1) Create the default user representation
   const userRepresentation = defaultsDeep(
     new UserRepresentation(),
     teamUserCfgTpl(email, firstName, lastName, groups, initialPassword),
   )
+
+  // 2) Transform the email string: "demo@example.com" -> "demo-example-com"
+  const transformedEmail = email.replace(/@/g, '-').replace(/\./g, '-')
+
+  // 3) Store it in a custom user attribute
+  userRepresentation.attributes = userRepresentation.attributes || {}
+  userRepresentation.attributes['transformedEmail'] = transformedEmail
+
   return userRepresentation
 }
 
@@ -158,7 +167,6 @@ export function mapTeamsToRoles(
   const teams =
     idpGroupMappings ??
     teamIds.reduce((memo: any, name) => {
-      // eslint-disable-next-line no-param-reassign
       memo[`team-${name}`] = undefined
       return memo
     }, {})

--- a/src/tasks/keycloak/realm-factory.ts
+++ b/src/tasks/keycloak/realm-factory.ts
@@ -125,18 +125,10 @@ export function createTeamUser(
   groups: string[],
   initialPassword: string,
 ): UserRepresentation {
-  // 1) Create the default user representation
   const userRepresentation = defaultsDeep(
     new UserRepresentation(),
     teamUserCfgTpl(email, firstName, lastName, groups, initialPassword),
   )
-
-  // 2) Transform the email string: "demo@example.com" -> "demo-example-com"
-  const transformedEmail = email.replace(/@/g, '-').replace(/\./g, '-')
-
-  // 3) Store it in a custom user attribute
-  userRepresentation.attributes = userRepresentation.attributes || {}
-  userRepresentation.attributes['transformedEmail'] = transformedEmail
 
   return userRepresentation
 }

--- a/src/tasks/keycloak/realm-factory.ts
+++ b/src/tasks/keycloak/realm-factory.ts
@@ -118,6 +118,7 @@ export function createAdminUser(username: string, password: string): UserReprese
   const userRepresentation = defaultsDeep(new UserRepresentation(), adminUserCfgTpl(username, password))
   return userRepresentation
 }
+
 export function createTeamUser(
   email: string,
   firstName: string,
@@ -129,7 +130,6 @@ export function createTeamUser(
     new UserRepresentation(),
     teamUserCfgTpl(email, firstName, lastName, groups, initialPassword),
   )
-  console.info('createTeamUser' + JSON.stringify(userRepresentation))
   return userRepresentation
 }
 

--- a/src/tasks/keycloak/realm-factory.ts
+++ b/src/tasks/keycloak/realm-factory.ts
@@ -23,7 +23,7 @@ import {
   protocolMappersList,
   realmCfgTpl,
   roleTpl,
-  teamUserCfgTpl,
+  teamUserCfgTpl, transformedEmailScope,
 } from './config'
 
 export function createClient(redirectUris: string[], webOrigins: string, secret: string): ClientRepresentation {
@@ -184,4 +184,8 @@ export function mapTeamsToRoles(
 
 export function createLoginThemeConfig(loginTheme = 'APL'): RealmRepresentation {
   return defaultsDeep(new RealmRepresentation(), { loginTheme })
+}
+
+export function createTransformedEmailScope(): ClientScopeRepresentation {
+  return defaultsDeep(new ClientScopeRepresentation(), transformedEmailScope)
 }

--- a/src/tasks/keycloak/realm-factory.ts
+++ b/src/tasks/keycloak/realm-factory.ts
@@ -129,7 +129,7 @@ export function createTeamUser(
     new UserRepresentation(),
     teamUserCfgTpl(email, firstName, lastName, groups, initialPassword),
   )
-
+  console.info('createTeamUser' + JSON.stringify(userRepresentation))
   return userRepresentation
 }
 

--- a/src/tasks/keycloak/realm-factory.ts
+++ b/src/tasks/keycloak/realm-factory.ts
@@ -23,7 +23,7 @@ import {
   protocolMappersList,
   realmCfgTpl,
   roleTpl,
-  teamUserCfgTpl, transformedEmailScope,
+  teamUserCfgTpl,
 } from './config'
 
 export function createClient(redirectUris: string[], webOrigins: string, secret: string): ClientRepresentation {
@@ -184,8 +184,4 @@ export function mapTeamsToRoles(
 
 export function createLoginThemeConfig(loginTheme = 'APL'): RealmRepresentation {
   return defaultsDeep(new RealmRepresentation(), { loginTheme })
-}
-
-export function createTransformedEmailScope(): ClientScopeRepresentation {
-  return defaultsDeep(new ClientScopeRepresentation(), transformedEmailScope)
 }


### PR DESCRIPTION
This fills the nickname attribute in keycloak for users with the email address where the `@` and `.` are replaced with a `-`