### PR TITLE
fix: apl-430 with prefix

### DIFF
--- a/src/operator/gitea.test.ts
+++ b/src/operator/gitea.test.ts
@@ -6,7 +6,7 @@ describe('giteaOperator', () => {
   it('should create a valid group mapping string with all the teams', () => {
     const mappingString = buildTeamString(teamNames)
     expect(mappingString).to.be.equal(
-      '{"platform-admin":{"otomi":["Owners"]},"team-demo":{"otomi":["otomi-viewer","team-demo"],"demo":["owners"]},"team-demo2":{"otomi":["otomi-viewer","team-demo2"],"demo2":["owners"]},"team-demo3":{"otomi":["otomi-viewer","team-demo3"],"demo3":["owners"]}}',
+      '{"platform-admin":{"otomi":["Owners"]},"team-demo":{"otomi":["otomi-viewer","team-demo"],"demo":["Owners"]},"team-demo2":{"otomi":["otomi-viewer","team-demo2"],"demo2":["Owners"]},"team-demo3":{"otomi":["otomi-viewer","team-demo3"],"demo3":["Owners"]}}',
     )
     expect(mappingString).to.not.contain('team-admin')
   })

--- a/src/operator/gitea.ts
+++ b/src/operator/gitea.ts
@@ -247,7 +247,7 @@ async function upsertOrganization(
   existingOrganizations: Organization[],
   organizationName: string,
 ): Promise<void> {
-  const prefixedOrgName = organizationName.includes('otomi') ? `team-${organizationName}` : organizationName
+  const prefixedOrgName = !organizationName.includes('otomi') ? `team-${organizationName}` : organizationName
   const orgOption = {
     ...new CreateOrgOption(),
     username: prefixedOrgName,

--- a/src/operator/gitea.ts
+++ b/src/operator/gitea.ts
@@ -247,7 +247,7 @@ async function upsertOrganization(
   existingOrganizations: Organization[],
   organizationName: string,
 ): Promise<void> {
-  const prefixedOrgName = `team-${organizationName}`
+  const prefixedOrgName = organizationName.includes('otomi') ? `team-${organizationName}` : organizationName
   const orgOption = {
     ...new CreateOrgOption(),
     username: prefixedOrgName,


### PR DESCRIPTION
This PR adds the team- prefix to organizations to be inline with harbor teams.
Also updated the owners to Owners
![image](https://github.com/user-attachments/assets/6768ff81-9580-4b80-9e1d-7aaa81d66285)
