### PR TITLE
feat: look up Gitea pod using selector

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@apidevtools/json-schema-ref-parser": "9.0.6",
         "@kubernetes/client-node": "1.1.2",
         "@linode/apl-k8s-operator": "0.1.0",
-        "@linode/gitea-client-node": "1.19.1",
+        "@linode/gitea-client-node": "1.23.6",
         "@linode/harbor-client-node": "^2.2.1",
         "@linode/keycloak-client-node": "^15.0.0",
         "async-retry": "^1.3.3",
@@ -4132,9 +4132,9 @@
       }
     },
     "node_modules/@linode/gitea-client-node": {
-      "version": "1.19.1",
-      "resolved": "https://npm.pkg.github.com/download/@linode/gitea-client-node/1.19.1/451e26ee65622aea481b6b963bf29fcffd71294a",
-      "integrity": "sha512-xiC6kt3wmGZ7Km3CvtUcbHugte4Q6Kl4Of5sKtYdlJw7v4dSFOdigxXdIiMHrqn+pkvdgRIP9e/NLugBtCdpAw==",
+      "version": "1.23.6",
+      "resolved": "https://npm.pkg.github.com/download/@linode/gitea-client-node/1.23.6/d179d40b4bbfe5171e9d0da0522f70f9260c6f07",
+      "integrity": "sha512-09kVWywWTP0TYRDJaQNO9jedk5OMOlB77cnhipLLQ3EO7XuMJjj/6G/RhRYNH95mGU9EruDfi+e5S+vz58Yucg==",
       "license": "Unlicense",
       "dependencies": {
         "bluebird": "^3.7.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@apidevtools/json-schema-ref-parser": "9.0.6",
     "@kubernetes/client-node": "1.1.2",
     "@linode/apl-k8s-operator": "0.1.0",
-    "@linode/gitea-client-node": "1.19.1",
+    "@linode/gitea-client-node": "1.23.6",
     "@linode/harbor-client-node": "^2.2.1",
     "@linode/keycloak-client-node": "^15.0.0",
     "async-retry": "^1.3.3",

--- a/src/operator/gitea.ts
+++ b/src/operator/gitea.ts
@@ -784,22 +784,17 @@ export function buildTeamString(teamNames: any[]): string {
 }
 
 async function getGiteaPodName(namespace: string): Promise<string | undefined> {
-  try {
-    const k8sApi = kc.makeApiClient(k8s.CoreV1Api)
-    const giteaPods = await k8sApi.listNamespacedPod({
-      namespace,
-      labelSelector: 'app.kubernetes.io/instance=gitea,app.kubernetes.io/name=gitea',
-      limit: 1,
-    })
-    if (giteaPods.items.length === 0) {
-      console.debug('Not ready for setting up OIDC config: Gitea pod not found.')
-      return
-    }
-    return giteaPods.items[0].metadata?.name
-  } catch (error) {
-    console.debug(`Error retrieving pod for Gitea OIDC config: ${error}`)
-    throw error
+  const k8sApi = kc.makeApiClient(k8s.CoreV1Api)
+  const giteaPods = await k8sApi.listNamespacedPod({
+    namespace,
+    labelSelector: 'app.kubernetes.io/instance=gitea,app.kubernetes.io/name=gitea',
+    limit: 1,
+  })
+  if (giteaPods.items.length === 0) {
+    console.debug('Not ready for setting up OIDC config: Gitea pod not found.')
+    return
   }
+  return giteaPods.items[0].metadata?.name
 }
 
 async function setGiteaOIDCConfig(update = false) {

--- a/src/operator/gitea.ts
+++ b/src/operator/gitea.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import { Exec, KubeConfig, KubernetesObject, V1Status } from '@kubernetes/client-node'
+import { CoreV1Api, Exec, KubeConfig, KubernetesObject, V1Status } from '@kubernetes/client-node'
 import Operator, { ResourceEvent, ResourceEventType } from '@linode/apl-k8s-operator'
 import {
   AdminApi,
@@ -784,7 +784,7 @@ export function buildTeamString(teamNames: any[]): string {
 }
 
 async function getGiteaPodName(namespace: string): Promise<string | undefined> {
-  const k8sApi = kc.makeApiClient(k8s.CoreV1Api)
+  const k8sApi = kc.makeApiClient(CoreV1Api)
   const giteaPods = await k8sApi.listNamespacedPod({
     namespace,
     labelSelector: 'app.kubernetes.io/instance=gitea,app.kubernetes.io/name=gitea',

--- a/src/operator/gitea.ts
+++ b/src/operator/gitea.ts
@@ -273,7 +273,7 @@ export const createServiceAccounts = async (
   organizations: Organization[],
   orgApi: OrganizationApi,
 ) => {
-  const users: User[] = await doApiCall(errors, `Getting all users`, () => adminApi.adminGetAllUsers())
+  const users: User[] = await doApiCall(errors, `Getting all users`, () => adminApi.adminSearchUsers())
   const filteredOrganizations = organizations.filter((org) => org.name !== 'otomi')
   await Promise.all(
     filteredOrganizations.map(async (organization) => {


### PR DESCRIPTION
This PR updates the method for executing commands directly in the Gitea pod. The Gitea Helm chart in recent versions uses Deployment instead of a StatefulSet, which requires looking up the Gitea pod by selectors instead of using a hard-coded name.

The code changes itself should work both on the current Core `main` as well as the feature branch. However, the pod permissions need to be updated, which is implemented in the feature branch only.

Core PR: https://github.com/linode/apl-core/pull/2085