### PR TITLE
fix: add sub claim mapper to admin realm

### DIFF
--- a/src/tasks/keycloak/config.ts
+++ b/src/tasks/keycloak/config.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-template-curly-in-string */
-/* eslint-disable camelcase */
 import { ProtocolMapperRepresentation } from '@linode/keycloak-client-node'
 import axios from 'axios'
 
@@ -214,6 +212,23 @@ export const clientEmailClaimMapper = (): Record<string, unknown> => ({
     'access.token.claim': 'true',
     'claim.name': 'email',
     'jsonType.label': 'String',
+  },
+})
+
+export const clientSubClaimMapper = (): Record<string, unknown> => ({
+  name: 'sub',
+  protocol: 'openid-connect',
+  protocolMapper: 'oidc-usermodel-property-mapper',
+  consentRequired: false,
+  config: {
+    'access.token.claim': 'true',
+    'claim.name': 'sub',
+    'id.token.claim': 'true',
+    'introspection.token.claim': 'true',
+    'jsonType.label': 'String',
+    'lightweight.claim': 'true',
+    'user.attribute': 'email',
+    'userinfo.token.claim': 'true',
   },
 })
 

--- a/src/tasks/keycloak/realm-factory.ts
+++ b/src/tasks/keycloak/realm-factory.ts
@@ -16,6 +16,7 @@ import {
   adminUserCfgTpl,
   clientEmailClaimMapper,
   clientScopeCfgTpl,
+  clientSubClaimMapper,
   defaultsIdpMapperTpl,
   idpMapperTpl,
   idpProviderCfgTpl,
@@ -114,6 +115,11 @@ export function createClientEmailClaimMapper(): ProtocolMapperRepresentation {
   return emailClaimMapper
 }
 
+export function createClientSubClaimMapper(): ProtocolMapperRepresentation {
+  const subClaimMapper = defaultsDeep(new ProtocolMapperRepresentation(), clientSubClaimMapper())
+  return subClaimMapper
+}
+
 export function createAdminUser(username: string, password: string): UserRepresentation {
   const userRepresentation = defaultsDeep(new UserRepresentation(), adminUserCfgTpl(username, password))
   return userRepresentation
@@ -158,7 +164,6 @@ export function mapTeamsToRoles(
   const teams =
     idpGroupMappings ??
     teamIds.reduce((memo: any, name) => {
-      // eslint-disable-next-line no-param-reassign
       memo[`team-${name}`] = undefined
       return memo
     }, {})


### PR DESCRIPTION
This PR adds the sub claim mapper to the admin realm so that the sub property will exist on the api token which is needed for istio to accept the request.