### PR TITLE
fix(keycloak): find the managed client by id, not by name

### DIFF
--- a/src/operators/keycloak/keycloak.ts
+++ b/src/operators/keycloak/keycloak.ts
@@ -36,6 +36,7 @@ import {
   createLoginThemeConfig,
   createRealm,
   createTeamUser,
+  findManagedClient,
   mapTeamsToRoles,
 } from '../../tasks/keycloak/realm-factory'
 import { isObjectSubsetDifferent } from '../../utils'
@@ -544,7 +545,7 @@ async function keycloakRealmProviderConfigurer(api: KeycloakApi) {
   const client = createClient(uniqueUrls, env.KEYCLOAK_HOSTNAME_URL, env.KEYCLOAK_CLIENT_SECRET)
   console.info('Getting otomi client')
   const allClients = (await api.clients.adminRealmsRealmClientsGet(keycloakRealm)).body
-  const existingClient = allClients.find((el) => el.name === client.name)
+  const existingClient = findManagedClient(allClients)
   if (existingClient) {
     if (isObjectSubsetDifferent(client, existingClient)) {
       console.info('Updating otomi client')

--- a/src/tasks/keycloak/config.ts
+++ b/src/tasks/keycloak/config.ts
@@ -329,12 +329,18 @@ export const idpProviderCfgTpl = async (
   }
 }
 
+// The Keycloak identity of the client this operator manages. It is pinned as the
+// client's `id` below, and Keycloak surfaces the same value as `clientId`. Both
+// are unique per realm, which is what makes them safe to look the client up by --
+// see findManagedClient in realm-factory.ts.
+export const otomiClientId = 'otomi'
+
 export const otomiClientCfgTpl = (
   secret: string,
   redirectUris: string[],
   webOrigins: string[],
 ): Record<string, unknown> => ({
-  id: 'otomi',
+  id: otomiClientId,
   secret,
   defaultClientScopes: ['openid', 'email', 'profile'],
   redirectUris,

--- a/src/tasks/keycloak/realm-factory.test.ts
+++ b/src/tasks/keycloak/realm-factory.test.ts
@@ -1,0 +1,49 @@
+import { ClientRepresentation } from '@linode/keycloak-client-node'
+import { findManagedClient } from './realm-factory'
+
+const client = (fields: Partial<ClientRepresentation>): ClientRepresentation => fields as ClientRepresentation
+
+describe('findManagedClient', () => {
+  it('finds the managed client by its pinned id', () => {
+    const all = [client({ id: 'account', name: '${client_account}' }), client({ id: 'otomi' })]
+    expect(findManagedClient(all)?.id).toBe('otomi')
+  })
+
+  it('finds the managed client by clientId when its internal id is a generated uuid', () => {
+    // A realm where the client was not created with the id pinned by
+    // otomiClientCfgTpl still has to resolve, or the caller falls to its create
+    // branch and POSTs a clientId that is already taken.
+    const all = [client({ id: '9f1c-uuid', clientId: 'otomi' })]
+    expect(findManagedClient(all)?.id).toBe('9f1c-uuid')
+  })
+
+  it('does not match an unrelated client that happens to have no name', () => {
+    // The regression this replaces: the old lookup was `el.name === client.name`
+    // with client.name undefined, i.e. "the first client with no name". A nameless
+    // public client sorting earlier captured it, and the operator then PUT
+    // authorizationServicesEnabled onto it -- Keycloak 500s, the realm reconcile
+    // aborts before manageUsers, and APL console users are never created.
+    const all = [client({ id: 'llz', clientId: 'llz', publicClient: true }), client({ id: 'otomi' })]
+    expect(findManagedClient(all)?.id).toBe('otomi')
+  })
+
+  it('is not confused by several nameless clients', () => {
+    const all = [
+      client({ id: 'aaa', clientId: 'aaa' }),
+      client({ id: 'llz-smoke-171', clientId: 'llz-smoke-171' }),
+      client({ id: 'otomi' }),
+      client({ id: 'zzz', clientId: 'zzz' }),
+    ]
+    expect(findManagedClient(all)?.id).toBe('otomi')
+  })
+
+  it('returns undefined when the managed client is absent, so the caller creates it', () => {
+    expect(findManagedClient([client({ id: 'llz', clientId: 'llz' })])).toBeUndefined()
+    expect(findManagedClient([])).toBeUndefined()
+  })
+
+  it('accepts an explicit clientId', () => {
+    const all = [client({ id: 'otomi' }), client({ id: 'other', clientId: 'other' })]
+    expect(findManagedClient(all, 'other')?.id).toBe('other')
+  })
+})

--- a/src/tasks/keycloak/realm-factory.ts
+++ b/src/tasks/keycloak/realm-factory.ts
@@ -24,6 +24,7 @@ import {
   idpMapperTpl,
   idpProviderCfgTpl,
   otomiClientCfgTpl,
+  otomiClientId,
   protocolMappersList,
   realmCfgTpl,
   roleTpl,
@@ -36,6 +37,42 @@ export function createClient(redirectUris: string[], webOrigins: string, secret:
     otomiClientCfgTpl(secret, redirectUris, [webOrigins]),
   )
   return otomiClientRepresentation
+}
+
+/**
+ * Find the client this operator manages among the realm's clients.
+ *
+ * Matching is on Keycloak's identity fields -- `id` (pinned by otomiClientCfgTpl)
+ * and `clientId` (the same value, and unique per realm). It deliberately does NOT
+ * match on `name`.
+ *
+ * The previous lookup was `allClients.find((el) => el.name === client.name)`, and
+ * because otomiClientCfgTpl sets no `name`, that expression evaluated to "the
+ * first client in the realm with no name". That is correct only while this client
+ * is the only nameless one, which nothing in the realm enforces: any client
+ * created through the admin API without a `name` -- by an operator in the console,
+ * or by external tooling that provisions its own OIDC client -- silently captures
+ * the lookup if its clientId sorts earlier.
+ *
+ * The consequence is severe and effectively invisible. The operator then PUTs this
+ * client's representation, including `authorizationServicesEnabled: true`, onto
+ * the intruder. If that client is public, Keycloak rejects it:
+ *
+ *     Only confidential clients are allowed to set authorization settings
+ *
+ * The 500 rolls the transaction back, so nothing in the realm drifts and nothing
+ * looks wrong afterwards -- but keycloakRealmProviderConfigurer aborts at this
+ * step on every 30s retry and never reaches IDPManager -> manageUsers. Users added
+ * in the APL console are never written to the realm, and logins fail with
+ * `user_not_found` for accounts that plainly exist in the `apl-users` namespace.
+ * Diagnosing that from the symptom takes a while; the operator log shows only a
+ * repeating "Updating otomi client" followed by a 500.
+ */
+export function findManagedClient(
+  allClients: ClientRepresentation[],
+  clientId: string = otomiClientId,
+): ClientRepresentation | undefined {
+  return allClients.find((el) => el.id === clientId || el.clientId === clientId)
 }
 
 export function createGroups(teamIds: string[]): Array<GroupRepresentation> {


### PR DESCRIPTION
## The bug

`keycloakRealmProviderConfigurer` locates the client it reconciles with:

```ts
const client = createClient(uniqueUrls, env.KEYCLOAK_HOSTNAME_URL, env.KEYCLOAK_CLIENT_SECRET)
const allClients = (await api.clients.adminRealmsRealmClientsGet(keycloakRealm)).body
const existingClient = allClients.find((el) => el.name === client.name)
```

`otomiClientCfgTpl` sets no `name`, so `client.name` is `undefined` and that
expression means **"the first client in the realm with no name"**.

That is correct only while the managed client is the only nameless one — and
nothing in the realm enforces it. Any client created through the admin API
without a `name` captures the lookup as soon as its `clientId` sorts earlier:
an operator adding one in the console, or external tooling provisioning its
own OIDC client.

## Why it is worth fixing rather than working around

The operator then PUTs the managed client's representation — including
`authorizationServicesEnabled: true` — onto the intruder. If that client is
public, Keycloak refuses it in `RepresentationToModel.createResourceServer`:

```
Only confidential clients are allowed to set authorization settings
```

The 500 **rolls the transaction back**, which is what makes this so hard to
see. Nothing drifts. The managed client stays confidential, the intruder keeps
working, and every client in the realm reads as correct.

But the reconcile aborts at this step on every 30s retry and never reaches
`IDPManager` → `manageUsers`. **Users added in the APL console are never
written to the realm.** Their logins fail `user_not_found` — surfaced in the UI
as "invalid username or password" — while their records sit in the `apl-users`
namespace, read correctly by the operator's own watcher. The operator log shows
only a repeating `Updating otomi client` followed by a 500 with no detail.

We hit this on a production cluster. Diagnosing it from the symptom took a
while, because every direct check of the realm says it is healthy.

## The change

Match on Keycloak's identity fields instead: `id` — which `otomiClientCfgTpl`
already pins to `otomi` — or `clientId`, the same value and unique per realm.

Accepting either keeps realms whose client was created *without* the pinned id
resolving as well, rather than falling to the create branch and POSTing a
`clientId` that is already taken.

The lookup moves to `realm-factory.ts` as `findManagedClient` so it can be
tested directly — `keycloakRealmProviderConfigurer` is not exported.

**It deliberately does not give the managed client a `name`.** That would also
fix the collision, but it would break a rollback to any earlier image, whose
nameless lookup would then miss the client and fall to its create branch.

## Tests

`src/tasks/keycloak/realm-factory.test.ts` — six cases: match by pinned id;
match by `clientId` when the internal id is a generated uuid; **do not** match
an unrelated nameless client (the regression); several nameless clients around
it; absent client returns `undefined` so the caller still creates it; explicit
clientId argument.

## One caveat on verification

I could not execute the suite locally: the `@linode/*` dependencies resolve
from GitHub Packages and `npm ci` fails with `401 ... authentication token not
provided`, so no dev dependencies install and jest cannot start. The changed
files parse clean, the diff is small, and the new test file has no dependency
beyond `findManagedClient` and the `ClientRepresentation` type — but CI running
green here is the real check, not my say-so.

Happy to adjust naming or move `findManagedClient` elsewhere if you would
rather it live with the operator.
